### PR TITLE
Fix failing publish

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 20.x
+          registry-url: https://registry.npmjs.org/
           cache: npm
           cache-dependency-path: package-lock.json
       # Must install dev dependencies explicitly in production env


### PR DESCRIPTION
Fix failing publish caused in `0.3.0` by removing NPM registry from Action